### PR TITLE
Use bitcoin2023 sync

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM arm64v8/ubuntu:20.04 as builder
 
-ARG VERSION=0.1.9
+ARG VERSION=0.1.11
 
 RUN apt-get update && apt-get install -y locales && rm -rf /var/lib/apt/lists/* \
 	&& localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,28 @@
+# `bgld-arm` changelog 
+
+## `v0.1.11` `BitcoinCore` sync - 18/05/2024
+
+Changes:
+
+- Synced with Bitcoin core upto 2023 - See [`v0.1.11` release notes](https://github.com/BitgesellOfficial/bitgesell/releases/tag/0.1.11)
+
+### How to get started:
+
+The image can be built from the `Dockerfile` by running:
+
+        docker build . -t bgld-arm
+
+A recommended security practice is to add an additional unprivileged user to run the daemon as on the host. For example, as a privileged user, run this on the host:
+
+        useradd bgld-arm
+
+To build an image which uses this unprivileged user's id and group id, run:
+
+        docker build --build-arg USER_ID=$( id -u bgld ) --build-arg GROUP_ID=$( id -g bgld-arm ) .
+
+Now, when the container is run with the default options, the bgld process will only have the privileges of the bgld user on the host machine. This is especially important for a process such as bgld-arm which runs as a network service exposed to the internet.
+
+## Initial release
+- Initial release is based on `0.1.9` release
+
+See release notes of [ Bitgesell Release 0.1.9](https://github.com/BitgesellOfficial/bitgesell/releases/tag/0.1.9)


### PR DESCRIPTION
## Summary

This pull request:
1. Updates Docker image to use Bitgesell core `v0.1.11` synced with Bitcoin core upto 2023 in this release: https://github.com/BitgesellOfficial/bitgesell/releases/tag/0.1.11

2.  Adds `CHANGELOG.md` with release history and changes for `bgld-arm`